### PR TITLE
Prep release 0 3 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>za.co.absa</groupId>
 	<artifactId>spark-hofs</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.3.0</version>
 
 	<packaging>jar</packaging>
 
@@ -49,7 +49,7 @@
 		<connection>scm:git:git://github.com/AbsaOSS/spark-hofs.git</connection>
 		<developerConnection>scm:git:ssh://github.com/AbsaOSS/spark-hofs.git</developerConnection>
 		<url>https://github.com/AbsaOSS/spark-hofs/tree/master</url>
-		<tag>HEAD</tag>
+		<tag>v0.3.0</tag>
 	</scm>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>za.co.absa</groupId>
 	<artifactId>spark-hofs</artifactId>
-	<version>0.3.0</version>
+	<version>0.3.1-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 
@@ -49,7 +49,7 @@
 		<connection>scm:git:git://github.com/AbsaOSS/spark-hofs.git</connection>
 		<developerConnection>scm:git:ssh://github.com/AbsaOSS/spark-hofs.git</developerConnection>
 		<url>https://github.com/AbsaOSS/spark-hofs/tree/master</url>
-		<tag>v0.3.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<licenses>


### PR DESCRIPTION
Release `spark-hofs` version `0.3.0` supporting Spark 2.4.2 (Scala 2.11)