### PR TITLE
#14 Add support for spark 3.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.11.12, 2.12.12]
-        spark: [2.4.7, 3.0.1]
+        scala: [2.11.12, 2.12.15]
+        spark: [2.4.7, 3.2.1]
         exclude:
           - scala: 2.11.12
-            spark: 3.0.1
+            spark: 3.2.1
     name: Test Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:
       - name: Checkout code

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-sbt.version=1.4.6
+sbt.version=1.5.8

--- a/src/test/scala/za/co/absa/spark/hofs/FilterFunctionSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hofs/FilterFunctionSuite.scala
@@ -40,6 +40,10 @@ class FilterFunctionSuite extends FunSuite with TestBase with Matchers {
     val resultField = df.select(function).schema.fields.head.name
 
     result shouldEqual expected
-    resultField shouldEqual "filter(array, lambdafunction(((myelm % 2) = 0), myelm))"
+    if (spark.version.startsWith("2") || spark.version.startsWith("3.1")) {
+      resultField shouldEqual "filter(array, lambdafunction(((myelm % 2) = 0), myelm))"
+    } else {
+      resultField shouldEqual "filter(array, lambdafunction(((namedlambdavariable() % 2) = 0), namedlambdavariable()))"
+    }
   }
 }

--- a/src/test/scala/za/co/absa/spark/hofs/ZipWithFunctionSuite.scala
+++ b/src/test/scala/za/co/absa/spark/hofs/ZipWithFunctionSuite.scala
@@ -40,6 +40,10 @@ class ZipWithFunctionSuite extends FunSuite with TestBase with Matchers {
     val resultField = df.select(function).schema.fields.head.name
 
     result shouldEqual expected
-    resultField shouldEqual "zip_with(array1, array2, lambdafunction((myelm1 + myelm2), myelm1, myelm2))"
+    if (spark.version.startsWith("2") || spark.version.startsWith("3.1")) {
+      resultField shouldEqual "zip_with(array1, array2, lambdafunction((myelm1 + myelm2), myelm1, myelm2))"
+    } else {
+      resultField shouldEqual "zip_with(array1, array2, lambdafunction((namedlambdavariable() + namedlambdavariable()), namedlambdavariable(), namedlambdavariable()))"
+    }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-version in ThisBuild := "0.4.1-SNAPSHOT"
+ThisBuild / version := "0.4.1-SNAPSHOT"


### PR DESCRIPTION
- update `sbt` version
- update `version.sbt` syntax
- update GH Action test.yml with new spark and scala
- update the tests to accommodate the change of not resolving lambda names to column names
- update the tests to use `hofs.` prefix when calling methods to avoid ambiguity

Closes #14 