### PR TITLE
#16 - Add code coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,12 @@ scala> df.withColumn("output", zip_with('input1, 'input2, (x, y) => x + y)).show
 ```
 The lambda variables indicating input elements to the merging function will be seen as `left` and `right` in
 Spark execution plans. The names can be changed by passing extra arguments to the **zip_with** function.
+
+## How to generate Code coverage report
+```sbt
+sbt jacoco
+```
+Code coverage will be generated on path:
+```
+{local-path}\spark-hofs\target\scala-2.XY\jacoco\report\html
+```

--- a/build.sbt
+++ b/build.sbt
@@ -45,3 +45,17 @@ lazy val hofs = (project in file("."))
 // release settings
 releaseCrossBuild := true
 addCommandAlias("releaseNow", ";set releaseVersionBump := sbtrelease.Version.Bump.Bugfix; release with-defaults")
+
+// JaCoCo code coverage
+Test / jacocoReportSettings := JacocoReportSettings(
+  s"spark-hofs Jacoco Report - ${scalaVersion.value}",
+  None,
+  JacocoThresholds(),
+  Seq(JacocoReportFormats.HTML, JacocoReportFormats.XML),
+  "utf-8")
+
+// exclude example
+Test / jacocoExcludes := Seq(
+//  "za.co.absa.spark.hofs.Extensions*", // class and related objects
+//  "za.co.absa.spark.hofs.package" // class only
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,4 +16,5 @@
 
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.12")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.6.0")
+addSbtPlugin("com.github.sbt"    % "sbt-jacoco"    % "3.4.0")


### PR DESCRIPTION
- added new plugin dependency
- extended `readme.md` file with how to get code coverage report
- extended build logic to add JaCoCo non-default settings

Closes #16 